### PR TITLE
fix: Resolve devcontainer startup issues with mise installation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,6 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},
-    "ghcr.io/jdx/mise/mise:1": {
-      "version": "latest"
-    },
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
@@ -118,7 +115,7 @@
   },
 
   // Commands to run after the container is created
-  "postCreateCommand": "chmod +x .devcontainer/*.sh && mise trust -- --non-interactive && bash .devcontainer/setup.sh",
+  "postCreateCommand": "sudo bash .devcontainer/init.sh",
 
   // Commands to run when starting the container
   "postStartCommand": "bash .devcontainer/post-start.sh",

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# DevContainer initialization script
+# This script installs mise and prepares the environment
+
+set -e
+
+echo "🔧 Installing mise..."
+
+# Set up for vscode user (since script may run as root)
+VSCODE_HOME="/home/vscode"
+
+# Ensure proper ownership of home directory
+chown -R vscode:vscode $VSCODE_HOME
+
+# Create necessary directories as vscode user
+sudo -u vscode mkdir -p $VSCODE_HOME/.local/{bin,share}
+sudo -u vscode chmod 755 $VSCODE_HOME/.local $VSCODE_HOME/.local/bin $VSCODE_HOME/.local/share
+
+# Install mise as vscode user
+sudo -u vscode bash -c 'curl -fsSL https://mise.jdx.dev/install.sh | sh'
+
+# Add mise activation to shell profiles as vscode user
+if ! sudo -u vscode grep -q "mise activate bash" $VSCODE_HOME/.bashrc; then
+    sudo -u vscode bash -c 'echo '\''eval "$(~/.local/bin/mise activate bash)"'\'' >> ~/.bashrc'
+fi
+
+if ! sudo -u vscode grep -q "mise activate zsh" $VSCODE_HOME/.zshrc; then
+    sudo -u vscode bash -c 'echo '\''eval "$(~/.local/bin/mise activate zsh)"'\'' >> ~/.zshrc'
+fi
+
+# Make scripts executable
+chmod +x .devcontainer/*.sh
+
+echo "✅ Mise installation completed!"
+echo "🎯 Ready for setup on next start!"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -5,8 +5,16 @@
 
 echo "🔄 DevContainer post-start setup..."
 
-# Activate mise
-eval "$(mise activate bash)"
+# Activate mise (use full path initially)
+eval "$(~/.local/bin/mise activate bash)"
+
+# Run setup script on first start
+if [ ! -f ~/.devcontainer-setup-done ]; then
+    echo "🚀 Running initial setup..."
+    bash .devcontainer/setup.sh
+    touch ~/.devcontainer-setup-done
+    echo "✅ Initial setup completed!"
+fi
 
 # Show current tool versions
 echo "📋 Current tool versions:"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,11 +7,11 @@ set -e
 
 echo "🚀 Starting DevContainer setup with mise (Dockerfileless)..."
 
-# Wait for mise to be fully installed by the devcontainer feature
+# Wait for mise to be fully installed
 sleep 2
 
-# Activate mise for this script
-eval "$(mise activate bash)"
+# Activate mise for this script (using full path)
+eval "$(~/.local/bin/mise activate bash)"
 
 # Verify mise installation
 echo "📋 Verifying mise installation..."
@@ -31,9 +31,13 @@ echo "Black: $(mise exec -- black --version)"
 echo "TypeScript: $(mise exec -- tsc --version)"
 echo "ESLint: $(mise exec -- eslint --version)"
 
-# Add mise activation to shell profiles
-echo 'eval "$(mise activate bash)"' >> ~/.bashrc
-echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+# Add mise activation to shell profiles (if not already present)
+if ! grep -q "mise activate bash" ~/.bashrc; then
+    echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+fi
+if ! grep -q "mise activate zsh" ~/.zshrc; then
+    echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc
+fi
 
 # Ensure proper PATH for mise tools
 echo 'export PATH="$HOME/.local/share/mise/shims:$PATH"' >> ~/.bashrc


### PR DESCRIPTION
- Remove problematic ghcr.io/jdx/mise/mise:1 feature that caused permission errors
- Add dedicated init.sh script for clean mise installation with proper user permissions
- Implement staged setup process: init.sh (postCreateCommand) → setup.sh (postStartCommand)
- Fix bashrc activation paths to use full ~/.local/bin/mise path
- Add duplicate entry checks to prevent bashrc pollution
- Ensure vscode user ownership and permissions throughout setup process

🤖 Generated with [Claude Code](https://claude.ai/code)